### PR TITLE
chore: add macOS and Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
 
   test_windows:
     name: Windows
+    # Use windows-2019, which is a lot faster than windows-2022:
+    # https://github.com/actions/runner-images/issues/5166
     runs-on: windows-2019
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,21 +11,62 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
 
-  build:
-    name: Build
+  test_linux:
+    name: Linux
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v3
-      with:
-        go-version: ^1.20
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
+
+    - name: Set up Go 1.20
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: '${{ github.workspace }}/go.mod'
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v -race -bench=. ./... -benchtime=100ms
+      run: go test -v -race -bench '.' ./... -benchtime=100ms
+  
+
+  test_macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Set up Go 1.20
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: '${{ github.workspace }}/go.mod'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v -race -bench '.' ./... -benchtime=100ms
+
+
+  test_windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Set up Go 1.20
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: '${{ github.workspace }}/go.mod'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v -race -bench '.' -benchtime=100ms ./...
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
   test_windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
 
     - name: Check out code into the Go module directory

--- a/transport/shadowsocks/client/stream_dialer_test.go
+++ b/transport/shadowsocks/client/stream_dialer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShadowsocksStreamDialer_Dial(t *testing.T) {
@@ -73,43 +74,46 @@ func TestShadowsocksStreamDialer_DialNoPayload(t *testing.T) {
 func TestShadowsocksStreamDialer_DialFastClose(t *testing.T) {
 	// Set up a listener that verifies no data is sent.
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
-	if err != nil {
-		t.Fatalf("ListenTCP failed: %v", err)
-	}
+	require.Nilf(t, err, "ListenTCP failed: %v", err)
+	defer listener.Close()
 
-	done := make(chan struct{})
+	var running sync.WaitGroup
+	running.Add(2)
+	// Server
 	go func() {
+		defer running.Done()
 		conn, err := listener.Accept()
-		if err != nil {
-			t.Error(err)
-		}
+		require.Nil(t, err)
+		defer conn.Close()
 		buf := make([]byte, 64)
 		n, err := conn.Read(buf)
 		if n > 0 || err != io.EOF {
 			t.Errorf("Expected EOF, got %v, %v", buf[:n], err)
 		}
-		listener.Close()
-		close(done)
 	}()
 
-	key := makeTestKey(t)
-	proxyEndpoint := transport.TCPEndpoint{RemoteAddr: *listener.Addr().(*net.TCPAddr)}
-	d, err := NewShadowsocksStreamDialer(proxyEndpoint, key)
-	if err != nil {
-		t.Fatalf("Failed to create StreamDialer: %v", err)
-	}
-	conn, err := d.Dial(context.Background(), testTargetAddr)
-	if err != nil {
-		t.Fatalf("StreamDialer.Dial failed: %v", err)
-	}
+	// Client
+	go func() {
+		defer running.Done()
+		key := makeTestKey(t)
+		proxyEndpoint := transport.TCPEndpoint{RemoteAddr: *listener.Addr().(*net.TCPAddr)}
+		d, err := NewShadowsocksStreamDialer(proxyEndpoint, key)
+		require.Nilf(t, err, "Failed to create StreamDialer: %v", err)
+		// Extend the wait to be safer.
+		d.ClientDataWait = 100 * time.Millisecond
 
-	// Wait for less than 10 milliseconds to ensure that the target
-	// address is not sent.
-	time.Sleep(1 * time.Millisecond)
-	// Close the connection before the target address is sent.
-	conn.Close()
+		conn, err := d.Dial(context.Background(), testTargetAddr)
+		require.Nilf(t, err, "StreamDialer.Dial failed: %v", err)
+
+		// Wait for less than 100 milliseconds to ensure that the target
+		// address is not sent.
+		time.Sleep(1 * time.Millisecond)
+		// Close the connection before the target address is sent.
+		conn.Close()
+	}()
+
 	// Wait for the listener to verify the close.
-	<-done
+	running.Wait()
 }
 
 func TestShadowsocksStreamDialer_TCPPrefix(t *testing.T) {


### PR DESCRIPTION
This is to make sure we stay cross-platform.

Note that the Windows build and test is [a lot slower than Linux and Windows](https://github.com/actions/runner-images/issues/7320). Because of that, I had to change the wait in one of the tests.

Also, I'm using windows-2019, which is at least 2x faster than windows-latest: https://github.com/actions/runner-images/issues/5166

On macOS, I ran into an issue where CloseRead on a connection that was already fully read causes an error, so I needed to update the test there too. It was a huge pain to figure out what was going on.