### PR TITLE
Add instructions for cross-platform development

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Windows example:
 
 ## Running Linux binaries
 
-To run Linux binaries we use a Linux container via [Podman](https://podman.io/).
+To run Linux binaries you can use a Linux container via [Podman](https://podman.io/).
 
 ### Set up podman
 <details>
@@ -138,3 +138,43 @@ Flags explanation:
 - `-t` (tty): Allocate a pseudo-TTY for container
 - `-v` (volume): Bind mount a volume into the container. Volume source will be on the server machine, not the client
 </details>
+
+## Running Windows binaries
+
+To run Windows binaries you can use [Wine](https://en.wikipedia.org/wiki/Wine_(software)) to emulate a Windows environment.
+This is not the same as a real Windows environment, so make sure you test on actual Windows machines.
+
+### Install Wine
+
+<details>
+  <summary>Instructions</summary>
+
+Follow the instructions at https://wiki.winehq.org/Download.
+
+On macOS: 
+```
+brew tap homebrew/cask-versions
+brew install --cask --no-quarantine wine-stable
+```
+
+After installation, `wine64` should be on your `PATH`. Check with:
+```
+wine64 --version
+```
+
+</details>
+
+### Run
+
+You can pass `wine64` as the `-exec` parameter in the `go` calls.
+
+To build:
+
+```sh
+GOOS=windows go run -C x -exec "wine64" ./outline-connectivity
+```
+
+For tests:
+```sh
+GOOS=windows go test -exec "wine64"  ./...
+```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Windows example:
 
 To run Linux binaries we use a Linux container via [Podman](https://podman.io/).
 
-## Set up podman
+### Set up podman
 <details>
   <summary>Instructions</summary>
 
@@ -97,7 +97,7 @@ podman machine stop
 ```
 </details>
 
-## Run
+### Run
 
 The easiest way is to run using `go run` directly with the `--exec` flag and our convenience tool `run_on_podman.sh`:
 ```sh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Tentative roadmap:
 
 ## Building
 
-In Go, you can compile for other target operating system and architecture by specifying the `GOOS` and `GOARCH` environment variables.
+In Go you can compile for other target operating system and architecture by specifying the `GOOS` and `GOARCH` environment variables. That only works if you are not using [Cgo](https://pkg.go.dev/cmd/cgo) to call C code.
 
 <details>
   <summary>Examples</summary>

--- a/README.md
+++ b/README.md
@@ -28,3 +28,113 @@ Tentative roadmap:
 
 - VPN API
   - [ ] VPN API for desktop (Linux, Windows, macOS)
+
+# Cross-platform Development
+
+## Building
+
+In Go, you can compile for other target operating system and architecture by specifying the `GOOS` and `GOARCH` environment variables.
+
+<details>
+  <summary>Examples</summary>
+
+MacOS example:
+```
+% GOOS=darwin go build -C x -o ./bin/ ./outline-connectivity 
+% file ./x/bin/outline-connectivity 
+./x/bin/outline-connectivity: Mach-O 64-bit executable x86_64
+```
+
+Linux example:
+```
+% GOOS=linux go build -C x -o ./bin/ ./outline-connectivity 
+% file ./x/bin/outline-connectivity                      
+./x/bin/outline-connectivity: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=n0WfUGLum4Y6OpYxZYuz/lbtEdv_kvyUCd3V_qOqb/CC_6GAQqdy_ebeYTdn99/Tk_G3WpBWi8vxqmIlIuU, with debug_info, not stripped
+```
+
+Windows example:
+```
+% GOOS=windows go build -C x -o ./bin/ ./outline-connectivity 
+% file ./x/bin/outline-connectivity.exe 
+./x/bin/outline-connectivity.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+```
+</details>
+
+## Running Linux binaries
+
+To run Linux binaries we use a Linux container via [Podman](https://podman.io/).
+
+## Set up podman
+<details>
+  <summary>Instructions</summary>
+
+[Install Podman](https://podman.io/docs/installation)
+On macOS (once):
+```sh
+brew install podman
+```
+
+Create the podman service VM (once):
+```sh
+podman machine init
+```
+
+Start the VM (after every time it is stopped):
+```sh
+podman machine start
+``` 
+
+You can see it running with `podman machine list`:
+```
+% podman machine list
+NAME                     VM TYPE     CREATED        LAST UP            CPUS        MEMORY      DISK SIZE
+podman-machine-default*  qemu        3 minutes ago  Currently running  1           2.147GB     107.4GB
+```
+
+When you are done with development, you can stop the machine:
+```sh
+podman machine stop
+```
+</details>
+
+## Run
+
+The easiest way is to run using `go run` directly with the `--exec` flag and our convenience tool `run_on_podman.sh`:
+```sh
+GOOS=linux go run -C x -exec "$(pwd)/run_on_podman.sh" ./outline-connectivity
+```
+
+It also works for tests:
+```sh
+GOOS=linux go test -exec "$(pwd)/run_on_podman.sh"  ./...
+```
+
+<details>
+  <summary>Details and direct invocation</summary>
+
+The `run_on_podman.sh` script uses `podman run` and the minimal [Alpine Linux](https://en.wikipedia.org/wiki/Alpine_Linux) to run the binary you want:
+```sh
+podman run --rm -it -v "${bin}":/outline/bin alpine /outline/bin "$@"
+```
+
+You can also use `podman` directly to run a pre-built binary:
+```
+% podman run --rm -it -v ./x/bin:/outline alpine /outline/outline-connectivity
+Usage of /outline/outline-connectivity:
+  -domain string
+        Domain name to resolve in the test (default "example.com.")
+  -key string
+        Outline access key
+  -proto string
+        Comma-separated list of the protocols to test. Muse be "tcp", "udp", or a combination of them (default "tcp,udp")
+  -resolver string
+        Comma-separated list of addresses of DNS resolver to use for the test (default "8.8.8.8,2001:4860:4860::8888")
+  -v    Enable debug output
+```
+
+Flags explanation:
+- `--rm`: Remove container (and pod if created) after exit
+- `-i` (interactive): Keep STDIN open even if not attached
+- `-t` (tty): Allocate a pseudo-TTY for container
+- `-v` (volume): Bind mount a volume into the container. Volume source will be on the server machine, not the client
+</details>

--- a/run_on_podman.sh
+++ b/run_on_podman.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2023 Jigsaw Operations LLC
 #

--- a/run_on_podman.sh
+++ b/run_on_podman.sh
@@ -16,8 +16,8 @@
 
 function main() {
   declare -r bin="$1"
-  shift 2
-  podman run --rm -it -v "${bin}":/outline/bin alpine /outline/bin "$@"
+  shift 1
+  podman run --arch $(uname -m) --rm -it -v "${bin}":/outline/bin alpine /outline/bin "$@"
 }
 
 main "$@"

--- a/run_on_podman.sh
+++ b/run_on_podman.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2023 Jigsaw Operations LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function main() {
+  declare -r bin="$1"
+  shift 2
+  podman run --rm -it -v "${bin}":/outline/bin alpine /outline/bin "$@"
+}
+
+main "$@"

--- a/run_on_podman.sh
+++ b/run_on_podman.sh
@@ -16,6 +16,7 @@
 
 function main() {
   declare -r bin="$1"
+  # Remove the binary name from the args
   shift 1
   podman run --arch $(uname -m) --rm -it -v "${bin}":/outline/bin alpine /outline/bin "$@"
 }

--- a/run_on_podman.sh
+++ b/run_on_podman.sh
@@ -18,7 +18,8 @@ function main() {
   declare -r bin="$1"
   # Remove the binary name from the args
   shift 1
-  podman run --arch $(uname -m) --rm -it -v "${bin}":/outline/bin alpine /outline/bin "$@"
+  # We are using Google's ~2MB minimal image. See https://github.com/GoogleContainerTools/distroless.
+  podman run --arch $(uname -m) --rm -it -v "${bin}":/outline/bin gcr.io/distroless/static-debian11 /outline/bin "$@"
 }
 
 main "$@"


### PR DESCRIPTION
BIG BREAKTHROUGH!

I realized I can build all our code in all platforms with `GOOS` and `GOARCH`. This makes development a lot better.
For running the code, we can use podman+minimal image for Linux and wine for Windows. I no longer need to depend on long iterations using the CI!