### PR TITLE
cleanup: use NoError consistently

### DIFF
--- a/transport/address_test.go
+++ b/transport/address_test.go
@@ -25,7 +25,7 @@ func TestMakeNetAddrType(t *testing.T) {
 	for _, address := range []string{"example.com:53", "127.0.0.1:443", "[::1]:443"} {
 		for _, network := range []string{"tcp", "udp"} {
 			netAddr, err := MakeNetAddr(network, address)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, network, netAddr.Network())
 			require.Equal(t, address, netAddr.String())
 			if address == "example.com:53" {
@@ -44,24 +44,24 @@ func TestMakeNetAddrType(t *testing.T) {
 
 func TestMakeNetAddrDomainCase(t *testing.T) {
 	netAddr, err := MakeNetAddr("tcp", "Example.Com:83")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "Example.Com:83", netAddr.String())
 }
 
 func TestMakeNetAddrIP4(t *testing.T) {
 	netAddr, err := MakeNetAddr("tcp", "127.0.0.1:83")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1:83", netAddr.String())
 }
 
 func TestMakeNetAddrIP6(t *testing.T) {
 	netAddr, err := MakeNetAddr("tcp", "[0000:0000:0000::0001]:83")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "[::1]:83", netAddr.String())
 }
 
 func TestMakeNetAddrResolvePort(t *testing.T) {
 	netAddr, err := MakeNetAddr("udp", "example.com:domain")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "example.com:53", netAddr.String())
 }

--- a/transport/packet_test.go
+++ b/transport/packet_test.go
@@ -36,7 +36,7 @@ func TestUDPEndpointIPv4(t *testing.T) {
 		return nil
 	}
 	conn, err := ep.Connect(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "udp", conn.RemoteAddr().Network())
 	assert.Equal(t, serverAddr, conn.RemoteAddr().String())
 }
@@ -50,7 +50,7 @@ func TestUDPEndpointIPv6(t *testing.T) {
 		return nil
 	}
 	conn, err := ep.Connect(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "udp", conn.RemoteAddr().Network())
 	assert.Equal(t, serverAddr, conn.RemoteAddr().String())
 }
@@ -64,7 +64,7 @@ func TestUDPEndpointDomain(t *testing.T) {
 		return nil
 	}
 	conn, err := ep.Connect(context.Background())
-	require.ErrorIs(t, err, nil)
+	require.NoError(t, err)
 	assert.Equal(t, "udp", conn.RemoteAddr().Network())
 	assert.Equal(t, resolvedAddr, conn.RemoteAddr().String())
 }
@@ -74,30 +74,30 @@ func TestUDPEndpointDomain(t *testing.T) {
 func TestUDPPacketListenerLocalIPv4Addr(t *testing.T) {
 	listener := &UDPPacketListener{Address: "127.0.0.1:0"}
 	pc, err := listener.ListenPacket(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "udp", pc.LocalAddr().Network())
 	listenIP, _, err := net.SplitHostPort(pc.LocalAddr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1", listenIP)
 }
 
 func TestUDPPacketListenerLocalIPv6Addr(t *testing.T) {
 	listener := &UDPPacketListener{Address: "[::1]:0"}
 	pc, err := listener.ListenPacket(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "udp", pc.LocalAddr().Network())
 	listenIP, _, err := net.SplitHostPort(pc.LocalAddr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "::1", listenIP)
 }
 
 func TestUDPPacketListenerLocalhost(t *testing.T) {
 	listener := &UDPPacketListener{Address: "localhost:0"}
 	pc, err := listener.ListenPacket(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "udp", pc.LocalAddr().Network())
 	listenIP, _, err := net.SplitHostPort(pc.LocalAddr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1", listenIP)
 }
 
@@ -105,9 +105,9 @@ func TestUDPPacketListenerDefaulAddr(t *testing.T) {
 	listener := &UDPPacketListener{}
 	pc, err := listener.ListenPacket(context.Background())
 	require.Equal(t, "udp", pc.LocalAddr().Network())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	listenIP, _, err := net.SplitHostPort(pc.LocalAddr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "::", listenIP)
 }
 
@@ -115,27 +115,27 @@ func TestUDPPacketListenerDefaulAddr(t *testing.T) {
 
 func TestUDPPacketDialer(t *testing.T) {
 	server, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "udp", server.LocalAddr().Network())
 
 	dialer := &UDPPacketDialer{}
 	conn, err := dialer.Dial(context.Background(), server.LocalAddr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	request := []byte("PING")
 	conn.Write(request)
 	receivedRequest := make([]byte, 5)
 	n, clientAddr, err := server.ReadFrom(receivedRequest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, request, receivedRequest[:n])
 
 	response := []byte("PONG")
 	n, err = server.WriteTo(response, clientAddr)
-	require.ErrorIs(t, err, nil)
+	require.NoError(t, err)
 	require.Equal(t, 4, n)
 	receivedResponse := make([]byte, 5)
 	n, err = conn.Read(receivedResponse)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, response, receivedResponse[:n])
 }
 
@@ -147,7 +147,7 @@ func TestPacketListenerDialer(t *testing.T) {
 
 	serverListener := UDPPacketListener{Address: "127.0.0.1:0"}
 	serverPacketConn, err := serverListener.ListenPacket(context.Background())
-	require.Nilf(t, err, "Failed to create UDP listener: %v", err)
+	require.NoError(t, err, "Failed to create UDP listener: %v", err)
 	t.Logf("Listening on %v", serverPacketConn.LocalAddr())
 	defer serverPacketConn.Close()
 
@@ -159,11 +159,11 @@ func TestPacketListenerDialer(t *testing.T) {
 		defer running.Done()
 		receivedRequest := make([]byte, len(request)+1)
 		n, clientAddr, err := serverPacketConn.ReadFrom(receivedRequest)
-		require.Nilf(t, err, "ReadFrom failed: %v", err)
+		require.NoError(t, err, "ReadFrom failed: %v", err)
 		require.Equal(t, request, receivedRequest[:n])
 
 		n, err = serverPacketConn.WriteTo(response, clientAddr)
-		require.Nilf(t, err, "WriteTo failed: %v", err)
+		require.NoError(t, err, "WriteTo failed: %v", err)
 		require.Equal(t, len(response), n)
 	}()
 
@@ -181,7 +181,7 @@ func TestPacketListenerDialer(t *testing.T) {
 			Listener: UDPPacketListener{Address: "127.0.0.1:0"},
 		}
 		conn, err := serverEndpoint.Dial(context.Background(), serverPacketConn.LocalAddr().String())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		t.Logf("Connected to %v from %v", conn.RemoteAddr(), conn.LocalAddr())
 		defer func() {
 			require.Nil(t, conn.Close())
@@ -190,12 +190,12 @@ func TestPacketListenerDialer(t *testing.T) {
 		require.True(t, ok)
 
 		n, err := conn.Write(request)
-		require.Nilf(t, err, "Failed Write: %v", err)
+		require.NoError(t, err, "Failed Write: %v", err)
 		require.Equal(t, len(request), n)
 
 		receivedResponse := make([]byte, len(response))
 		n, err = conn.Read(receivedResponse)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, response, receivedResponse[:n])
 
 	}()
@@ -207,11 +207,11 @@ func TestPacketListenerDialer(t *testing.T) {
 
 func TestPacketConnInvalidArgument(t *testing.T) {
 	serverListener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
-	require.ErrorIs(t, err, nil)
+	require.NoError(t, err)
 	t.Logf("Listening on %v", serverListener.LocalAddr())
 
 	netAddr, err := MakeNetAddr("udp", "localhost:8888")
-	require.ErrorIs(t, err, nil)
+	require.NoError(t, err)
 
 	_, err = serverListener.WriteTo([]byte("PING"), netAddr)
 	// This returns Invalid Argument because netAddr is not a *UDPAddr

--- a/transport/shadowsocks/cipher_test.go
+++ b/transport/shadowsocks/cipher_test.go
@@ -23,11 +23,11 @@ import (
 
 func assertCipher(t *testing.T, cipher string, saltSize, tagSize int) {
 	key, err := NewEncryptionKey(cipher, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, saltSize, key.SaltSize())
 
 	dummyAead, err := key.NewAEAD(make([]byte, key.SaltSize()))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, tagSize, key.TagSize())
 	require.Equal(t, key.TagSize(), dummyAead.Overhead())
 }
@@ -42,19 +42,19 @@ func TestSizes(t *testing.T) {
 
 func TestShadowsocksCipherNames(t *testing.T) {
 	key, err := NewEncryptionKey("chacha20-ietf-poly1305", "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, chacha20IETFPOLY1305Cipher, key.cipher)
 
 	key, err = NewEncryptionKey("aes-256-gcm", "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, aes256GCMCipher, key.cipher)
 
 	key, err = NewEncryptionKey("aes-192-gcm", "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, aes192GCMCipher, key.cipher)
 
 	key, err = NewEncryptionKey("aes-128-gcm", "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, aes128GCMCipher, key.cipher)
 }
 
@@ -87,7 +87,7 @@ func TestMaxTagSize(t *testing.T) {
 	var calculatedMax int
 	for _, cipher := range supportedCiphers {
 		key, err := NewEncryptionKey(cipher, "")
-		if !assert.Nilf(t, err, "Failed to create cipher %v", cipher) {
+		if !assert.NoError(t, err, "Failed to create cipher %v", cipher) {
 			continue
 		}
 		assert.LessOrEqualf(t, key.TagSize(), maxTagSize, "Tag size for cipher %v (%v) is greater than the max (%v)", cipher, key.TagSize(), maxTagSize)

--- a/transport/shadowsocks/compatibility_test.go
+++ b/transport/shadowsocks/compatibility_test.go
@@ -35,7 +35,7 @@ func TestCompatibility(t *testing.T) {
 	var wait sync.WaitGroup
 	wait.Add(1)
 	key, err := NewEncryptionKey(cipherName, secret)
-	require.Nil(t, err, "NewCipher failed: %v", err)
+	require.NoError(t, err, "NewCipher failed: %v", err)
 	ssWriter := NewWriter(left, key)
 	go func() {
 		defer wait.Done()
@@ -45,21 +45,21 @@ func TestCompatibility(t *testing.T) {
 		ssReader := NewReader(left, key)
 		receivedByLeft := make([]byte, len(fromRight))
 		_, err = ssReader.Read(receivedByLeft)
-		require.Nil(t, err, "Read failed: %v", err)
+		require.NoError(t, err, "Read failed: %v", err)
 		require.Equal(t, fromRight, string(receivedByLeft))
 		left.Close()
 	}()
 
 	otherCipher, err := core.PickCipher(cipherName, []byte{}, secret)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	rightSSConn := shadowaead.NewConn(right, otherCipher.(shadowaead.Cipher))
 	receivedByRight := make([]byte, len(fromLeft))
 	_, err = io.ReadFull(rightSSConn, receivedByRight)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, fromLeft, string(receivedByRight))
 
 	_, err = rightSSConn.Write([]byte(fromRight))
-	require.Nil(t, err, "Write failed: %v", err)
+	require.NoError(t, err, "Write failed: %v", err)
 
 	rightSSConn.Close()
 	wait.Wait()

--- a/transport/shadowsocks/packet_listener_test.go
+++ b/transport/shadowsocks/packet_listener_test.go
@@ -43,7 +43,7 @@ func TestShadowsocksPacketListener_ListenPacket(t *testing.T) {
 	conn.SetReadDeadline(time.Now().Add(time.Second * 5))
 	pcrw := &packetConnReadWriter{PacketConn: conn}
 	pcrw.targetAddr, err = transport.MakeNetAddr("udp", testTargetAddr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	expectEchoPayload(pcrw, makeTestPayload(1024), make([]byte, 1024), t)
 
 	proxy.Close()
@@ -57,7 +57,7 @@ func BenchmarkShadowsocksPacketListener_ListenPacket(b *testing.B) {
 	key := makeTestKey(b)
 	proxy, running := startShadowsocksUDPEchoServer(key, testTargetAddr, b)
 	targetAddr, err := transport.MakeNetAddr("udp", testTargetAddr)
-	require.Nil(b, err)
+	require.NoError(b, err)
 	proxyEndpoint := transport.UDPEndpoint{Address: proxy.LocalAddr().String()}
 	d, err := NewPacketListener(proxyEndpoint, key)
 	if err != nil {

--- a/transport/shadowsocks/packet_test.go
+++ b/transport/shadowsocks/packet_test.go
@@ -27,7 +27,7 @@ func BenchmarkPack(b *testing.B) {
 	b.ResetTimer()
 
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(b, err)
+	require.NoError(b, err)
 	MTU := 1500
 	pkt := make([]byte, MTU)
 	plaintextBuf := pkt[key.SaltSize() : len(pkt)-key.TagSize()]

--- a/transport/shadowsocks/stream_dialer_test.go
+++ b/transport/shadowsocks/stream_dialer_test.go
@@ -74,7 +74,7 @@ func TestStreamDialer_DialNoPayload(t *testing.T) {
 func TestStreamDialer_DialFastClose(t *testing.T) {
 	// Set up a listener that verifies no data is sent.
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
-	require.Nilf(t, err, "ListenTCP failed: %v", err)
+	require.NoError(t, err, "ListenTCP failed: %v", err)
 	defer listener.Close()
 
 	var running sync.WaitGroup
@@ -83,7 +83,7 @@ func TestStreamDialer_DialFastClose(t *testing.T) {
 	go func() {
 		defer running.Done()
 		conn, err := listener.Accept()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer conn.Close()
 		buf := make([]byte, 64)
 		n, err := conn.Read(buf)
@@ -98,12 +98,12 @@ func TestStreamDialer_DialFastClose(t *testing.T) {
 		key := makeTestKey(t)
 		proxyEndpoint := &transport.TCPEndpoint{Address: listener.Addr().String()}
 		d, err := NewStreamDialer(proxyEndpoint, key)
-		require.Nilf(t, err, "Failed to create StreamDialer: %v", err)
+		require.NoError(t, err, "Failed to create StreamDialer: %v", err)
 		// Extend the wait to be safer.
 		d.ClientDataWait = 100 * time.Millisecond
 
 		conn, err := d.Dial(context.Background(), testTargetAddr)
-		require.Nilf(t, err, "StreamDialer.Dial failed: %v", err)
+		require.NoError(t, err, "StreamDialer.Dial failed: %v", err)
 
 		// Wait for less than 100 milliseconds to ensure that the target
 		// address is not sent.

--- a/transport/shadowsocks/stream_test.go
+++ b/transport/shadowsocks/stream_test.go
@@ -19,7 +19,7 @@ const testCipherOverhead = 16
 
 func TestCipherReaderAuthenticationFailure(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	clientReader := strings.NewReader("Fails Authentication")
 	reader := NewReader(clientReader, key)
@@ -31,7 +31,7 @@ func TestCipherReaderAuthenticationFailure(t *testing.T) {
 
 func TestCipherReaderUnexpectedEOF(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	clientReader := strings.NewReader("short")
 	server := NewReader(clientReader, key)
@@ -41,7 +41,7 @@ func TestCipherReaderUnexpectedEOF(t *testing.T) {
 
 func TestCipherReaderEOF(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	clientReader := strings.NewReader("")
 	server := NewReader(clientReader, key)
@@ -82,7 +82,7 @@ func encryptBlocks(key *EncryptionKey, salt []byte, blocks [][]byte) (io.Reader,
 
 func TestCipherReaderGoodReads(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	salt := []byte("12345678901234567890123456789012")
 	if len(salt) != key.SaltSize() {
@@ -114,7 +114,7 @@ func TestCipherReaderGoodReads(t *testing.T) {
 
 func TestCipherReaderClose(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	pipeReader, pipeWriter := io.Pipe()
 	server := NewReader(pipeReader, key)
@@ -132,7 +132,7 @@ func TestCipherReaderClose(t *testing.T) {
 
 func TestCipherReaderCloseError(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	pipeReader, pipeWriter := io.Pipe()
 	server := NewReader(pipeReader, key)
@@ -150,7 +150,7 @@ func TestCipherReaderCloseError(t *testing.T) {
 
 func TestEndToEnd(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	connReader, connWriter := io.Pipe()
 	writer := NewWriter(connWriter, key)
@@ -180,17 +180,17 @@ func TestEndToEnd(t *testing.T) {
 
 func TestLazyWriteFlush(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf := new(bytes.Buffer)
 	writer := NewWriter(buf, key)
 	header := []byte{1, 2, 3, 4}
 	n, err := writer.LazyWrite(header)
-	require.Nilf(t, err, "LazyWrite failed: %v", err)
+	require.NoError(t, err, "LazyWrite failed: %v", err)
 	require.Equal(t, len(header), n, "Wrong write size")
 	require.Equal(t, 0, buf.Len(), "LazyWrite isn't lazy")
 
 	err = writer.Flush()
-	require.Nilf(t, err, "Flush failed: %v", err)
+	require.NoError(t, err, "Flush failed: %v", err)
 
 	len1 := buf.Len()
 	require.Greater(t, len1, len(header), "Not enough bytes flushed")
@@ -198,7 +198,7 @@ func TestLazyWriteFlush(t *testing.T) {
 	// Check that normal writes now work
 	body := []byte{5, 6, 7}
 	n, err = writer.Write(body)
-	require.Nilf(t, err, "Write failed: %v", err)
+	require.NoError(t, err, "Write failed: %v", err)
 	require.Equal(t, len(body), n, "Wrong write size")
 	require.Greater(t, buf.Len(), len1, "No write observed")
 
@@ -206,19 +206,19 @@ func TestLazyWriteFlush(t *testing.T) {
 	reader := NewReader(buf, key)
 	decrypted := make([]byte, len(header)+len(body))
 	n, err = reader.Read(decrypted)
-	require.Nilf(t, err, "Read failed: %v", err)
+	require.NoError(t, err, "Read failed: %v", err)
 	require.Equal(t, len(header), n, "Wrong number of bytes out")
 	require.Equal(t, header, decrypted[:n], "Wrong final content")
 
 	n, err = reader.Read(decrypted[n:])
-	require.Nilf(t, err, "Read failed: %v", err)
+	require.NoError(t, err, "Read failed: %v", err)
 	require.Equal(t, len(body), n, "Wrong number of bytes out")
 	require.Equal(t, body, decrypted[len(header):], "Wrong final content")
 }
 
 func TestLazyWriteConcat(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf := new(bytes.Buffer)
 	writer := NewWriter(buf, key)
 	header := []byte{1, 2, 3, 4}
@@ -273,7 +273,7 @@ func TestLazyWriteConcat(t *testing.T) {
 
 func TestLazyWriteOversize(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf := new(bytes.Buffer)
 	writer := NewWriter(buf, key)
 	N := 25000 // More than one block, less than two.
@@ -314,12 +314,12 @@ func TestLazyWriteOversize(t *testing.T) {
 
 func TestLazyWriteConcurrentFlush(t *testing.T) {
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf := new(bytes.Buffer)
 	writer := NewWriter(buf, key)
 	header := []byte{1, 2, 3, 4}
 	n, err := writer.LazyWrite(header)
-	require.Nilf(t, err, "LazyWrite failed: %v", err)
+	require.NoError(t, err, "LazyWrite failed: %v", err)
 	require.Equalf(t, len(header), n, "Wrong write size: %d", n)
 	require.Equal(t, 0, buf.Len(), "LazyWrite isn't lazy: %v", buf.Bytes())
 
@@ -329,7 +329,7 @@ func TestLazyWriteConcurrentFlush(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		n, err := writer.ReadFrom(r)
-		require.Nilf(t, err, "ReadFrom: %v", err)
+		require.NoError(t, err, "ReadFrom: %v", err)
 		require.Equalf(t, int64(len(body)), n, "ReadFrom: Wrong read size %d", n)
 		wg.Done()
 	}()
@@ -345,7 +345,7 @@ func TestLazyWriteConcurrentFlush(t *testing.T) {
 
 	// Check that normal writes now work
 	n, err = w.Write(body)
-	require.Nilf(t, err, "Write failed: %v", err)
+	require.NoError(t, err, "Write failed: %v", err)
 	require.Equalf(t, len(body), n, "Wrong write size: %d", n)
 
 	w.Close()
@@ -357,12 +357,12 @@ func TestLazyWriteConcurrentFlush(t *testing.T) {
 	decrypted := make([]byte, len(header)+len(body))
 	n, err = reader.Read(decrypted)
 	require.Equal(t, len(header), n, "Wrong number of bytes out")
-	require.Nilf(t, err, "Read failed: %v", err)
+	require.NoError(t, err, "Read failed: %v", err)
 
 	require.Equal(t, header, decrypted[:len(header)], "Wrong final content")
 
 	n, err = reader.Read(decrypted[len(header):])
-	require.Nilf(t, err, "Read failed: %v", err)
+	require.NoError(t, err, "Read failed: %v", err)
 	require.Equal(t, len(body), n, "Wrong number of bytes out")
 	require.Equal(t, body, decrypted[len(header):], "Wrong final content")
 }
@@ -383,7 +383,7 @@ func BenchmarkWriter(b *testing.B) {
 	b.ResetTimer()
 
 	key, err := NewEncryptionKey(CHACHA20IETFPOLY1305, "test secret")
-	require.Nil(b, err)
+	require.NoError(b, err)
 	writer := NewWriter(new(nullIO), key)
 
 	start := time.Now()

--- a/x/connectivity/connectivity_test.go
+++ b/x/connectivity/connectivity_test.go
@@ -37,7 +37,7 @@ func TestTestResolverStreamConnectivityOk(t *testing.T) {
 	// TODO(fortuna): Run a local resolver and make test not depend on an external server.
 	resolver := &transport.TCPEndpoint{Address: "8.8.8.8:53"}
 	_, err := TestResolverStreamConnectivity(context.Background(), resolver, "example.com")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // TODO: Move this to the SDK.
@@ -65,7 +65,7 @@ func runTestTCPServer(tb testing.TB, handle func(conn *net.TCPConn), running *sy
 
 func TestTestResolverStreamConnectivityRefused(t *testing.T) {
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IP{127, 0, 0, 1}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// Close right away to ensure the port is closed. The OS will likely not reuse it soon enough.
 	require.Nil(t, listener.Close())
 
@@ -97,7 +97,7 @@ func TestTestResolverStreamConnectivityReset(t *testing.T) {
 		// not reading any data may keep the client blocked on the write, causing inconsistent
 		// TestErr.Op results across OSes.
 		_, err := conn.Read(make([]byte, 1))
-		require.ErrorIs(t, err, nil)
+		require.NoError(t, err)
 		// This forces a reset when the connection is closed and there's data not acknowledged.
 		conn.SetLinger(0)
 		require.Nil(t, conn.Close())
@@ -131,7 +131,7 @@ func TestTestStreamDialerEarlyClose(t *testing.T) {
 		conn.CloseWrite()
 		// Consume all the incoming data to avoid a reset.
 		_, err := io.Copy(io.Discard, conn)
-		require.ErrorIs(t, err, nil)
+		require.NoError(t, err)
 		require.Nil(t, conn.Close())
 	}, &running)
 	defer listener.Close()
@@ -181,28 +181,28 @@ func TestTestResolverStreamConnectivityTimeout(t *testing.T) {
 
 func TestTestPacketPacketConnectivityOk(t *testing.T) {
 	server, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
-	require.ErrorIs(t, err, nil)
+	require.NoError(t, err)
 	defer server.Close()
 
 	go func() {
 		buf := make([]byte, 512)
 		n, clientAddr, err := server.ReadFrom(buf)
-		require.ErrorIs(t, err, nil)
+		require.NoError(t, err)
 		var request dns.Msg
 		err = request.Unpack(buf[:n])
-		require.ErrorIs(t, err, nil)
+		require.NoError(t, err)
 
 		var response dns.Msg
 		response.SetReply(&request)
 		responseBytes, err := response.Pack()
-		require.ErrorIs(t, err, nil)
+		require.NoError(t, err)
 		_, err = server.WriteTo(responseBytes, clientAddr)
-		require.ErrorIs(t, err, nil)
+		require.NoError(t, err)
 	}()
 
 	resolver := &transport.UDPEndpoint{Address: server.LocalAddr().String()}
 	_, err = TestResolverPacketConnectivity(context.Background(), resolver, "example.com")
-	require.ErrorIs(t, err, nil)
+	require.NoError(t, err)
 }
 
 // TODO: Add more tests


### PR DESCRIPTION
I was using a bunch of different things before. This is now much cleaner and expresses the intent better. I didn't know `NoError` existed.

I also found out that the calls ending in `f`  are unnecessary. The code decides on a string literal or template based on the number of arguments.